### PR TITLE
Add device token auth

### DIFF
--- a/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
@@ -1,0 +1,43 @@
+using Fuelflux.Core.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Fuelflux.Core.RestModels;
+using Fuelflux.Core.Services;
+using Fuelflux.Core.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Fuelflux.Core.Tests.Controllers;
+
+[TestFixture]
+public class PumpControllerTests
+{
+    private PumpController _controller = null!;
+    private DeviceAuthService _service = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = 1 });
+        _service = new DeviceAuthService(opts, new LoggerFactory().CreateLogger<DeviceAuthService>());
+        _controller = new PumpController(_service, new LoggerFactory().CreateLogger<PumpController>());
+    }
+
+    [Test]
+    public void Authorize_ReturnsValidToken()
+    {
+        var result = _controller.Authorize();
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var token = ((result.Result as OkObjectResult)!.Value as TokenResponse)!.Token;
+        Assert.That(_service.Validate(token), Is.True);
+    }
+
+    [Test]
+    public void Deauthorize_RemovesToken()
+    {
+        var token = _service.Authorize();
+        var res = _controller.Deauthorize(new TokenRequest { Token = token });
+        Assert.That(res, Is.TypeOf<OkResult>());
+        Assert.That(_service.Validate(token), Is.False);
+    }
+}

--- a/Fuelflux.Core.Tests/Services/DeviceAuthServiceTests.cs
+++ b/Fuelflux.Core.Tests/Services/DeviceAuthServiceTests.cs
@@ -1,0 +1,46 @@
+using Fuelflux.Core.Services;
+using Fuelflux.Core.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Fuelflux.Core.Tests.Services;
+
+[TestFixture]
+public class DeviceAuthServiceTests
+{
+    private DeviceAuthService _service = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = 1 });
+        var logger = new LoggerFactory().CreateLogger<DeviceAuthService>();
+        _service = new DeviceAuthService(opts, logger);
+    }
+
+    [Test]
+    public void Authorize_And_Validate_ReturnsTrue()
+    {
+        var token = _service.Authorize();
+        Assert.That(_service.Validate(token), Is.True);
+    }
+
+    [Test]
+    public void Deauthorize_RemovesToken()
+    {
+        var token = _service.Authorize();
+        _service.Deauthorize(token);
+        Assert.That(_service.Validate(token), Is.False);
+    }
+
+    [Test]
+    public void Validate_ReturnsFalse_WhenExpired()
+    {
+        var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = -1 });
+        var logger = new LoggerFactory().CreateLogger<DeviceAuthService>();
+        var svc = new DeviceAuthService(opts, logger);
+        var token = svc.Authorize();
+        Assert.That(svc.Validate(token), Is.False);
+    }
+}

--- a/Fuelflux.Core/Controllers/PumpController.cs
+++ b/Fuelflux.Core/Controllers/PumpController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Fuelflux.Core.Authorization;
+using Fuelflux.Core.RestModels;
+using Fuelflux.Core.Services;
+
+namespace Fuelflux.Core.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PumpController(IDeviceAuthService authService, ILogger<PumpController> logger) : ControllerBase
+{
+    private readonly IDeviceAuthService _authService = authService;
+    private readonly ILogger<PumpController> _logger = logger;
+
+    [HttpPost("authorize")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TokenResponse))]
+    public ActionResult<TokenResponse> Authorize()
+    {
+        var token = _authService.Authorize();
+        return Ok(new TokenResponse { Token = token });
+    }
+
+    [HttpPost("deauthorize")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult Deauthorize(TokenRequest request)
+    {
+        _authService.Deauthorize(request.Token);
+        return Ok();
+    }
+}

--- a/Fuelflux.Core/Program.cs
+++ b/Fuelflux.Core/Program.cs
@@ -47,8 +47,10 @@ builder.WebHost.ConfigureKestrel(options =>
 
 builder.Services
     .Configure<AppSettings>(builder.Configuration.GetSection("AppSettings"))
+    .Configure<DeviceAuthSettings>(builder.Configuration.GetSection("DeviceAuth"))
     .AddScoped<IJwtUtils, JwtUtils>()
     .AddScoped<IUserInformationService, UserInformationService>()
+    .AddSingleton<IDeviceAuthService, DeviceAuthService>()
     .AddHttpContextAccessor()
     .AddControllers();
 

--- a/Fuelflux.Core/RestModels/TokenRequest.cs
+++ b/Fuelflux.Core/RestModels/TokenRequest.cs
@@ -1,0 +1,6 @@
+namespace Fuelflux.Core.RestModels;
+
+public class TokenRequest
+{
+    public required string Token { get; set; }
+}

--- a/Fuelflux.Core/RestModels/TokenResponse.cs
+++ b/Fuelflux.Core/RestModels/TokenResponse.cs
@@ -1,0 +1,6 @@
+namespace Fuelflux.Core.RestModels;
+
+public class TokenResponse
+{
+    public required string Token { get; set; }
+}

--- a/Fuelflux.Core/Services/DeviceAuthService.cs
+++ b/Fuelflux.Core/Services/DeviceAuthService.cs
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Fuelflux Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Options;
@@ -22,7 +47,9 @@ public class DeviceAuthService : IDeviceAuthService
         var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
         var expires = DateTime.UtcNow.AddMinutes(_settings.SessionMinutes);
         _sessions[token] = expires;
-        _logger.LogDebug("Token {token} authorized until {expires}", token, expires);
+        
+        var tokenPrefix = GetSafeTokenIdentifier(token);
+        _logger.LogDebug("Token {tokenPrefix} authorized until {expires}", tokenPrefix, expires);
         return token;
     }
 
@@ -35,7 +62,9 @@ public class DeviceAuthService : IDeviceAuthService
                 return true;
             }
             _sessions.TryRemove(token, out _);
-            _logger.LogDebug("Token {token} expired", token);
+            
+            var tokenPrefix = GetSafeTokenIdentifier(token);
+            _logger.LogDebug("Token {tokenPrefix} expired", tokenPrefix);
         }
         return false;
     }
@@ -43,6 +72,13 @@ public class DeviceAuthService : IDeviceAuthService
     public void Deauthorize(string token)
     {
         _sessions.TryRemove(token, out _);
-        _logger.LogDebug("Token {token} deauthorized", token);
+        
+        var tokenPrefix = GetSafeTokenIdentifier(token);
+        _logger.LogDebug("Token {tokenPrefix} deauthorized", tokenPrefix);
+    }
+
+    private static string GetSafeTokenIdentifier(string token)
+    {
+        return token.Length > 8 ? $"{token[..8]}..." : "short_token";
     }
 }

--- a/Fuelflux.Core/Services/DeviceAuthService.cs
+++ b/Fuelflux.Core/Services/DeviceAuthService.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using Fuelflux.Core.Settings;
+
+namespace Fuelflux.Core.Services;
+
+public class DeviceAuthService : IDeviceAuthService
+{
+    private readonly ConcurrentDictionary<string, DateTime> _sessions = new();
+    private readonly DeviceAuthSettings _settings;
+    private readonly ILogger<DeviceAuthService> _logger;
+
+    public DeviceAuthService(IOptions<DeviceAuthSettings> options, ILogger<DeviceAuthService> logger)
+    {
+        _settings = options.Value;
+        _logger = logger;
+    }
+
+    public string Authorize()
+    {
+        var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
+        var expires = DateTime.UtcNow.AddMinutes(_settings.SessionMinutes);
+        _sessions[token] = expires;
+        _logger.LogDebug("Token {token} authorized until {expires}", token, expires);
+        return token;
+    }
+
+    public bool Validate(string token)
+    {
+        if (_sessions.TryGetValue(token, out var expires))
+        {
+            if (DateTime.UtcNow < expires)
+            {
+                return true;
+            }
+            _sessions.TryRemove(token, out _);
+            _logger.LogDebug("Token {token} expired", token);
+        }
+        return false;
+    }
+
+    public void Deauthorize(string token)
+    {
+        _sessions.TryRemove(token, out _);
+        _logger.LogDebug("Token {token} deauthorized", token);
+    }
+}

--- a/Fuelflux.Core/Services/IDeviceAuthService.cs
+++ b/Fuelflux.Core/Services/IDeviceAuthService.cs
@@ -1,4 +1,27 @@
-using Fuelflux.Core.RestModels;
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Fuelflux Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
 
 namespace Fuelflux.Core.Services;
 

--- a/Fuelflux.Core/Services/IDeviceAuthService.cs
+++ b/Fuelflux.Core/Services/IDeviceAuthService.cs
@@ -1,0 +1,10 @@
+using Fuelflux.Core.RestModels;
+
+namespace Fuelflux.Core.Services;
+
+public interface IDeviceAuthService
+{
+    string Authorize();
+    bool Validate(string token);
+    void Deauthorize(string token);
+}

--- a/Fuelflux.Core/Settings/DeviceAuthSettings.cs
+++ b/Fuelflux.Core/Settings/DeviceAuthSettings.cs
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Fuelflux Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 namespace Fuelflux.Core.Settings;
 
 public class DeviceAuthSettings

--- a/Fuelflux.Core/Settings/DeviceAuthSettings.cs
+++ b/Fuelflux.Core/Settings/DeviceAuthSettings.cs
@@ -1,0 +1,6 @@
+namespace Fuelflux.Core.Settings;
+
+public class DeviceAuthSettings
+{
+    public int SessionMinutes { get; set; } = 30;
+}

--- a/Fuelflux.Core/appsettings.json
+++ b/Fuelflux.Core/appsettings.json
@@ -11,5 +11,8 @@
   "AppSettings": {
     "Secret": "THIS IS USED TO SIGN AND VERIFY JWT TOKENS, REPLACE IT WITH YOUR OWN SECRET, IT CAN BE ANY STRING",
     "JwtTokenExpirationDays": 7
+  },
+  "DeviceAuth": {
+    "SessionMinutes": 30
   }
 }


### PR DESCRIPTION
## Summary
- implement `DeviceAuthService` with in-memory session tokens
- expose `/api/pump/authorize` and `/api/pump/deauthorize` endpoints
- wire up device auth service in Program.cs and config
- add REST models for token request/response
- test device auth service and pump controller

## Testing
- `dotnet test Fuelflux.Core.Tests/Fuelflux.Core.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_6881d89daed4832187ed462ccb93da3d