### PR TITLE
Add fuel station model hierarchy

### DIFF
--- a/Fuelflux.Core/Data/AppDbContext.cs
+++ b/Fuelflux.Core/Data/AppDbContext.cs
@@ -92,8 +92,8 @@ namespace Fuelflux.Core.Data
                 .HasForeignKey(ft => ft.FuelStationId);
 
             modelBuilder.Entity<FuelTank>()
-                .HasIndex(ft => ft.Number);
-
+                .HasIndex(ft => new { ft.FuelStationId, ft.Number })
+                .IsUnique();
             modelBuilder.Entity<PumpController>()
                 .HasOne(pc => pc.FuelStation)
                 .WithMany(fs => fs.PumpControllers)

--- a/Fuelflux.Core/Data/AppDbContext.cs
+++ b/Fuelflux.Core/Data/AppDbContext.cs
@@ -36,6 +36,9 @@ namespace Fuelflux.Core.Data
         public DbSet<User> Users => Set<User>();
         public DbSet<Role> Roles => Set<Role>();
         public DbSet<UserRole> UserRoles => Set<UserRole>();
+        public DbSet<FuelStation> FuelStations => Set<FuelStation>();
+        public DbSet<FuelTank> FuelTanks => Set<FuelTank>();
+        public DbSet<PumpController> PumpControllers => Set<PumpController>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -82,6 +85,19 @@ namespace Fuelflux.Core.Data
                 new UserRole { UserId = 1, RoleId = 2 }, // Operator
                 new UserRole { UserId = 1, RoleId = 3 }  // Customer
             );
+
+            modelBuilder.Entity<FuelTank>()
+                .HasOne(ft => ft.FuelStation)
+                .WithMany(fs => fs.FuelTanks)
+                .HasForeignKey(ft => ft.FuelStationId);
+
+            modelBuilder.Entity<FuelTank>()
+                .HasIndex(ft => ft.Number);
+
+            modelBuilder.Entity<PumpController>()
+                .HasOne(pc => pc.FuelStation)
+                .WithMany(fs => fs.PumpControllers)
+                .HasForeignKey(pc => pc.FuelStationId);
         }
     }
 }

--- a/Fuelflux.Core/Models/FuelStation.cs
+++ b/Fuelflux.Core/Models/FuelStation.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fuelflux.Core.Models;
+
+[Table("fuel_stations")]
+public class FuelStation
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("name")]
+    public required string Name { get; set; }
+
+    public ICollection<FuelTank> FuelTanks { get; set; } = [];
+    public ICollection<PumpController> PumpControllers { get; set; } = [];
+}

--- a/Fuelflux.Core/Models/FuelTank.cs
+++ b/Fuelflux.Core/Models/FuelTank.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fuelflux.Core.Models;
+
+[Table("fuel_tanks")]
+public class FuelTank
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("number", TypeName = "numeric(3)")]
+    public decimal Number { get; set; }
+
+    [Column("fuel_station_id")]
+    public int FuelStationId { get; set; }
+    public FuelStation FuelStation { get; set; } = null!;
+}

--- a/Fuelflux.Core/Models/PumpController.cs
+++ b/Fuelflux.Core/Models/PumpController.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fuelflux.Core.Models;
+
+[Table("pump_controllers")]
+public class PumpController
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("guid")]
+    public required string Guid { get; set; }
+
+    [Column("fuel_station_id")]
+    public int FuelStationId { get; set; }
+    public FuelStation FuelStation { get; set; } = null!;
+}

--- a/Fuelflux.Core/Models/PumpController.cs
+++ b/Fuelflux.Core/Models/PumpController.cs
@@ -9,7 +9,7 @@ public class PumpController
     public int Id { get; set; }
 
     [Column("guid")]
-    public required string Guid { get; set; }
+    public required Guid Guid { get; set; }
 
     [Column("fuel_station_id")]
     public int FuelStationId { get; set; }


### PR DESCRIPTION
## Summary
- add `FuelStation`, `FuelTank`, and `PumpController` models
- register the new models in `AppDbContext`
- configure relationships and index in `OnModelCreating`

## Testing
- `dotnet test Fuelflux.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688212122d248321b79726a318d96e80