### PR TITLE
Update pump authorization endpoint

### DIFF
--- a/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
@@ -5,6 +5,10 @@ using Fuelflux.Core.Services;
 using Fuelflux.Core.Settings;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.EntityFrameworkCore;
+using Fuelflux.Core.Data;
+using Fuelflux.Core.Models;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Fuelflux.Core.Tests.Controllers;
@@ -14,22 +18,76 @@ public class PumpControllerTests
 {
     private PumpController _controller = null!;
     private DeviceAuthService _service = null!;
+    private AppDbContext _context = null!;
 
     [SetUp]
     public void Setup()
     {
         var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = 1 });
         _service = new DeviceAuthService(opts, new LoggerFactory().CreateLogger<DeviceAuthService>());
-        _controller = new PumpController(_service, new LoggerFactory().CreateLogger<PumpController>());
+
+        var dbOptions = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"pump_controller_test_{Guid.NewGuid()}")
+            .Options;
+        _context = new AppDbContext(dbOptions);
+
+        // Seed roles
+        _context.Roles.AddRange(
+            new Role { Id = 1, RoleId = UserRoleConstants.Operator, Name = "Operator" },
+            new Role { Id = 2, RoleId = UserRoleConstants.Customer, Name = "Customer" }
+        );
+
+        // Seed users
+        _context.Users.AddRange(
+            new User
+            {
+                Id = 10,
+                Email = "op@test.com",
+                Password = "pwd",
+                Uid = "OPUID",
+                UserRoles = [ new() { UserId = 10, RoleId = 1 } ]
+            },
+            new User
+            {
+                Id = 11,
+                Email = "cust@test.com",
+                Password = "pwd",
+                Uid = "CUSTUID",
+                Allowance = 100m,
+                UserRoles = [ new() { UserId = 11, RoleId = 2 } ]
+            }
+        );
+
+        // Seed tanks
+        _context.FuelStations.Add(new FuelStation { Id = 1, Name = "FS" });
+        _context.FuelTanks.AddRange(
+            new FuelTank { Id = 1, Number = 1, FuelStationId = 1 },
+            new FuelTank { Id = 2, Number = 2, FuelStationId = 1 }
+        );
+
+        _context.SaveChanges();
+
+        _controller = new PumpController(_service, _context, new LoggerFactory().CreateLogger<PumpController>());
     }
 
     [Test]
-    public void Authorize_ReturnsValidToken()
+    public async Task Authorize_ReturnsCustomerRole()
     {
-        var result = _controller.Authorize();
+        var result = await _controller.Authorize(new PumpAuthorizeRequest { Uid = "CUSTUID" });
         Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
-        var token = ((result.Result as OkObjectResult)!.Value as TokenResponse)!.Token;
-        Assert.That(_service.Validate(token), Is.True);
+        var resp = (PumpAuthorizeResponse)((OkObjectResult)result.Result!).Value!;
+        Assert.That(resp.Role, Is.EqualTo("Пользователь"));
+        Assert.That(_service.Validate(resp.Token!), Is.True);
+    }
+
+    [Test]
+    public async Task Authorize_ReturnsOperatorRole()
+    {
+        var result = await _controller.Authorize(new PumpAuthorizeRequest { Uid = "OPUID" });
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var resp = (PumpAuthorizeResponse)((OkObjectResult)result.Result!).Value!;
+        Assert.That(resp.Role, Is.EqualTo("Оператор"));
+        Assert.That(resp.VirtualTanks, Is.Not.Null);
     }
 
     [Test]

--- a/Fuelflux.Core/Controllers/PumpController.cs
+++ b/Fuelflux.Core/Controllers/PumpController.cs
@@ -2,23 +2,76 @@ using Microsoft.AspNetCore.Mvc;
 using Fuelflux.Core.Authorization;
 using Fuelflux.Core.RestModels;
 using Fuelflux.Core.Services;
+using Fuelflux.Core.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace Fuelflux.Core.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class PumpController(IDeviceAuthService authService, ILogger<PumpController> logger) : ControllerBase
+public class PumpController(
+    IDeviceAuthService authService,
+    AppDbContext db,
+    ILogger<PumpController> logger) : ControllerBase
 {
     private readonly IDeviceAuthService _authService = authService;
+    private readonly AppDbContext _db = db;
     private readonly ILogger<PumpController> _logger = logger;
 
     [HttpPost("authorize")]
     [AllowAnonymous]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TokenResponse))]
-    public ActionResult<TokenResponse> Authorize()
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PumpAuthorizeResponse))]
+    public async Task<ActionResult<PumpAuthorizeResponse>> Authorize(PumpAuthorizeRequest request)
     {
         var token = _authService.Authorize();
-        return Ok(new TokenResponse { Token = token });
+        _logger.LogDebug("Authorize pump user with uid {uid}", request.Uid);
+
+        var user = await _db.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .FirstOrDefaultAsync(u => u.Uid == request.Uid);
+
+        if (user == null)
+        {
+            return Ok(new PumpAuthorizeResponse
+            {
+                Role = "Не авторизован",
+                Token = token
+            });
+        }
+
+        if (user.IsOperator())
+        {
+            var tanks = await _db.FuelTanks
+                .AsNoTracking()
+                .Select(t => new VirtualTankInfo
+                {
+                    Number = (int)t.Number,
+                    NominalVolume = 0m
+                })
+                .ToListAsync();
+
+            return Ok(new PumpAuthorizeResponse
+            {
+                Role = "Оператор",
+                VirtualTanks = tanks,
+                Token = token
+            });
+        }
+
+        if (user.IsCustomer())
+        {
+            return Ok(new PumpAuthorizeResponse
+            {
+                Role = "Пользователь",
+                MaxVolume = user.Allowance ?? 0m,
+                FuelPrice = 0m,
+                Token = token
+            });
+        }
+
+        return Ok(new PumpAuthorizeResponse { Role = "Не авторизован", Token = token });
     }
 
     [HttpPost("deauthorize")]

--- a/Fuelflux.Core/RestModels/PumpAuthorizeRequest.cs
+++ b/Fuelflux.Core/RestModels/PumpAuthorizeRequest.cs
@@ -1,0 +1,6 @@
+namespace Fuelflux.Core.RestModels;
+
+public class PumpAuthorizeRequest
+{
+    public required string Uid { get; set; }
+}

--- a/Fuelflux.Core/RestModels/PumpAuthorizeResponse.cs
+++ b/Fuelflux.Core/RestModels/PumpAuthorizeResponse.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Fuelflux.Core.RestModels;
+
+public class PumpAuthorizeResponse
+{
+    public required string Role { get; set; }
+    public decimal? MaxVolume { get; set; }
+    public decimal? FuelPrice { get; set; }
+    public List<VirtualTankInfo>? VirtualTanks { get; set; }
+    public string? Token { get; set; }
+}

--- a/Fuelflux.Core/RestModels/VirtualTankInfo.cs
+++ b/Fuelflux.Core/RestModels/VirtualTankInfo.cs
@@ -1,0 +1,7 @@
+namespace Fuelflux.Core.RestModels;
+
+public class VirtualTankInfo
+{
+    public required int Number { get; set; }
+    public required decimal NominalVolume { get; set; }
+}


### PR DESCRIPTION
## Summary
- enhance pump controller authorize endpoint to determine user roles and return new auth info
- add DTOs for pump authorization requests/responses
- expand pump controller tests for role-based authorization

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688221b882708321a385762f6532bdcc