### PR TITLE
Implement JWT device tokens with cleanup job

### DIFF
--- a/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
@@ -19,7 +19,8 @@ public class PumpControllerTests
     public void Setup()
     {
         var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = 1 });
-        _service = new DeviceAuthService(opts, new LoggerFactory().CreateLogger<DeviceAuthService>());
+        var appOpts = Options.Create(new AppSettings { Secret = "secret" });
+        _service = new DeviceAuthService(opts, appOpts, new LoggerFactory().CreateLogger<DeviceAuthService>());
         _controller = new PumpController(_service, new LoggerFactory().CreateLogger<PumpController>());
     }
 

--- a/Fuelflux.Core.Tests/Services/DeviceAuthServiceTests.cs
+++ b/Fuelflux.Core.Tests/Services/DeviceAuthServiceTests.cs
@@ -15,8 +15,9 @@ public class DeviceAuthServiceTests
     public void Setup()
     {
         var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = 1 });
+        var appOpts = Options.Create(new AppSettings { Secret = "secret" });
         var logger = new LoggerFactory().CreateLogger<DeviceAuthService>();
-        _service = new DeviceAuthService(opts, logger);
+        _service = new DeviceAuthService(opts, appOpts, logger);
     }
 
     [Test]
@@ -37,9 +38,10 @@ public class DeviceAuthServiceTests
     [Test]
     public void Validate_ReturnsFalse_WhenExpired()
     {
-        var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = -1 });
+        var opts = Options.Create(new DeviceAuthSettings { SessionMinutes = 0 });
+        var appOpts = Options.Create(new AppSettings { Secret = "secret" });
         var logger = new LoggerFactory().CreateLogger<DeviceAuthService>();
-        var svc = new DeviceAuthService(opts, logger);
+        var svc = new DeviceAuthService(opts, appOpts, logger);
         var token = svc.Authorize();
         Assert.That(svc.Validate(token), Is.False);
     }

--- a/Fuelflux.Core/Fuelflux.Core.csproj
+++ b/Fuelflux.Core/Fuelflux.Core.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Quartz" Version="3.14.0" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.14.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
     <PackageReference Include="SharpCompress" Version="0.40.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />

--- a/Fuelflux.Core/Jobs/DeviceTokenCleanupJob.cs
+++ b/Fuelflux.Core/Jobs/DeviceTokenCleanupJob.cs
@@ -1,0 +1,17 @@
+using Quartz;
+using Fuelflux.Core.Services;
+
+namespace Fuelflux.Core.Jobs;
+
+public class DeviceTokenCleanupJob(IDeviceAuthService authService, ILogger<DeviceTokenCleanupJob> logger) : IJob
+{
+    private readonly IDeviceAuthService _authService = authService;
+    private readonly ILogger<DeviceTokenCleanupJob> _logger = logger;
+
+    public Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Running device token cleanup job");
+        _authService.RemoveExpiredTokens();
+        return Task.CompletedTask;
+    }
+}

--- a/Fuelflux.Core/Program.cs
+++ b/Fuelflux.Core/Program.cs
@@ -55,15 +55,13 @@ builder.Services
     .AddSingleton<IDeviceAuthService, DeviceAuthService>()
     .AddQuartz(q =>
     {
-        q.UseMicrosoftDependencyInjectionJobFactory();
-
         var jobKey = new JobKey("deviceTokenCleanup");
         q.AddJob<DeviceTokenCleanupJob>(opts => opts.WithIdentity(jobKey));
-
+        var sc = builder.Configuration.GetSection("DeviceAuth").GetValue<string>("CleanupCron", "0 0 0 * * ?") ?? "0 0 0 * * ?";
         q.AddTrigger(opts => opts
             .ForJob(jobKey)
             .WithIdentity("deviceTokenCleanup-trigger")
-            .WithCronSchedule(builder.Configuration.GetSection("DeviceAuth").GetValue<string>("CleanupCron", "0 0 0 * * ?")));
+            .WithCronSchedule(sc));
     })
     .AddQuartzHostedService(opt => opt.WaitForJobsToComplete = true)
     .AddHttpContextAccessor()

--- a/Fuelflux.Core/Services/DeviceAuthService.cs
+++ b/Fuelflux.Core/Services/DeviceAuthService.cs
@@ -24,7 +24,11 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 using System.Collections.Concurrent;
+using System.Security.Claims;
 using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Text;
 using Microsoft.Extensions.Options;
 using Fuelflux.Core.Settings;
 
@@ -34,47 +38,111 @@ public class DeviceAuthService : IDeviceAuthService
 {
     private readonly ConcurrentDictionary<string, DateTime> _sessions = new();
     private readonly DeviceAuthSettings _settings;
+    private readonly AppSettings _appSettings;
     private readonly ILogger<DeviceAuthService> _logger;
 
-    public DeviceAuthService(IOptions<DeviceAuthSettings> options, ILogger<DeviceAuthService> logger)
+    public DeviceAuthService(
+        IOptions<DeviceAuthSettings> deviceOptions,
+        IOptions<AppSettings> appOptions,
+        ILogger<DeviceAuthService> logger)
     {
-        _settings = options.Value;
+        _settings = deviceOptions.Value;
+        _appSettings = appOptions.Value;
         _logger = logger;
+
+        if (string.IsNullOrEmpty(_appSettings.Secret))
+        {
+            _logger.LogError("JWT secret not configured");
+            throw new Exception("JWT secret not configured");
+        }
     }
 
     public string Authorize()
     {
-        var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(16));
-        var expires = DateTime.UtcNow.AddMinutes(_settings.SessionMinutes);
-        _sessions[token] = expires;
-        
-        var tokenPrefix = GetSafeTokenIdentifier(token);
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = SHA256.HashData(Encoding.UTF8.GetBytes(_appSettings.Secret!));
+
+        var now = DateTime.UtcNow;
+        var expires = now.AddMinutes(_settings.SessionMinutes);
+        var notBefore = expires <= now ? expires.AddSeconds(-1) : now;
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("typ", "device")
+            }),
+            Expires = expires,
+            NotBefore = notBefore,
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var tokenString = tokenHandler.WriteToken(token);
+
+        _sessions[tokenString] = expires;
+
+        var tokenPrefix = GetSafeTokenIdentifier(tokenString);
         _logger.LogDebug("Token {tokenPrefix} authorized until {expires}", tokenPrefix, expires);
-        return token;
+        return tokenString;
     }
 
     public bool Validate(string token)
     {
-        if (_sessions.TryGetValue(token, out var expires))
+        if (!_sessions.TryGetValue(token, out var expires))
         {
-            if (DateTime.UtcNow < expires)
-            {
-                return true;
-            }
-            _sessions.TryRemove(token, out _);
-            
-            var tokenPrefix = GetSafeTokenIdentifier(token);
-            _logger.LogDebug("Token {tokenPrefix} expired", tokenPrefix);
+            return false;
         }
-        return false;
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = SHA256.HashData(Encoding.UTF8.GetBytes(_appSettings.Secret!));
+        try
+        {
+            tokenHandler.ValidateToken(token, new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(key),
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ClockSkew = TimeSpan.Zero
+            }, out _);
+
+            if (DateTime.UtcNow >= expires)
+            {
+                _sessions.TryRemove(token, out _);
+                var tokenPrefix = GetSafeTokenIdentifier(token);
+                _logger.LogDebug("Token {tokenPrefix} expired", tokenPrefix);
+                return false;
+            }
+
+            return true;
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogWarning(ex, "Invalid device token");
+            _sessions.TryRemove(token, out _);
+            return false;
+        }
     }
 
     public void Deauthorize(string token)
     {
         _sessions.TryRemove(token, out _);
-        
+
         var tokenPrefix = GetSafeTokenIdentifier(token);
         _logger.LogDebug("Token {tokenPrefix} deauthorized", tokenPrefix);
+    }
+
+    public void RemoveExpiredTokens()
+    {
+        foreach (var kv in _sessions.ToArray())
+        {
+            if (kv.Value <= DateTime.UtcNow)
+            {
+                _sessions.TryRemove(kv.Key, out _);
+                var tokenPrefix = GetSafeTokenIdentifier(kv.Key);
+                _logger.LogDebug("Token {tokenPrefix} expired and removed", tokenPrefix);
+            }
+        }
     }
 
     private static string GetSafeTokenIdentifier(string token)

--- a/Fuelflux.Core/Services/IDeviceAuthService.cs
+++ b/Fuelflux.Core/Services/IDeviceAuthService.cs
@@ -30,4 +30,5 @@ public interface IDeviceAuthService
     string Authorize();
     bool Validate(string token);
     void Deauthorize(string token);
+    void RemoveExpiredTokens();
 }

--- a/Fuelflux.Core/Settings/DeviceAuthSettings.cs
+++ b/Fuelflux.Core/Settings/DeviceAuthSettings.cs
@@ -28,4 +28,5 @@ namespace Fuelflux.Core.Settings;
 public class DeviceAuthSettings
 {
     public int SessionMinutes { get; set; } = 30;
+    public string CleanupCron { get; set; } = "0 0 0 * * ?";
 }

--- a/Fuelflux.Core/appsettings.json
+++ b/Fuelflux.Core/appsettings.json
@@ -13,6 +13,7 @@
     "JwtTokenExpirationDays": 7
   },
   "DeviceAuth": {
-    "SessionMinutes": 30
+    "SessionMinutes": 30,
+    "CleanupCron": "0 0 0 * * ?"
   }
 }


### PR DESCRIPTION
## Summary
- generate device JWT tokens with configurable expiration
- allow removing expired device tokens
- configure Quartz daily cleanup job
- add cleanup schedule option
- update tests for new behavior

## Testing
- `dotnet build Fuelflux.sln --no-restore --nologo --verbosity minimal`
- `dotnet test Fuelflux.sln --no-restore --nologo --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6882764748f08321b3a3566a2ff4c4f7