### PR TITLE
Update pump deauthorize to use bearer token

### DIFF
--- a/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/PumpControllerTests.cs
@@ -85,7 +85,13 @@ public class PumpControllerTests
     public async Task Deauthorize_RemovesToken()
     {
         var token = _service.Authorize(_pump, _user);
-        var res = _controller.Deauthorize(new TokenRequest { Token = token });
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        _controller.ControllerContext.HttpContext.Request.Headers["Authorization"] = $"Bearer {token}";
+
+        var res = _controller.Deauthorize();
 
         await Task.Delay(1);
 

--- a/Fuelflux.Core/Controllers/PumpController.cs
+++ b/Fuelflux.Core/Controllers/PumpController.cs
@@ -40,9 +40,18 @@ public class PumpController(IDeviceAuthService authService, AppDbContext db, ILo
 
     [HttpPost("deauthorize")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public IActionResult Deauthorize(TokenRequest request)
+    [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+    public IActionResult Deauthorize()
     {
-        _authService.Deauthorize(request.Token);
+        var token = Request.Headers["Authorization"].FirstOrDefault()?.Split(' ').Last();
+        if (string.IsNullOrEmpty(token))
+        {
+            const string errorMessage = "Необходимо войти в систему.";
+            _logger.LogWarning(errorMessage);
+            return StatusCode(StatusCodes.Status401Unauthorized, new ErrMessage { Msg = errorMessage });
+        }
+
+        _authService.Deauthorize(token);
         return Ok();
     }
 }


### PR DESCRIPTION
## Summary
- remove token parameter from `PumpController.Deauthorize`
- read bearer token from `Authorization` header
- adjust pump controller tests accordingly

## Testing
- `dotnet test Fuelflux.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6882996035b88321936a9b6c9f39b099