### PR TITLE
Add PumpUserRequest DTO and validate GetPumpUsers

### DIFF
--- a/Fuelflux.Core/RestModels/PumpUserRequest.cs
+++ b/Fuelflux.Core/RestModels/PumpUserRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Fuelflux.Core.RestModels;
+
+public class PumpUserRequest
+{
+    [Range(0, int.MaxValue, ErrorMessage = "first must be non-negative.")]
+    public int First { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "number must be positive.")]
+    public int Number { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `PumpUserRequest` DTO for retrieving users via pump controller
- validate query parameters for GetPumpUsers
- switch query to role id checks for EF compatibility
- update and extend pump controller user list tests

## Testing
- `dotnet test Fuelflux.Core.Tests/Fuelflux.Core.Tests.csproj -c Release -v n`

------
https://chatgpt.com/codex/tasks/task_e_68834bc10868832199dce6dc1483b19b