### PR TITLE
Add PumpController error tests

### DIFF
--- a/Fuelflux.Core.Tests/Controllers/PumpControllerRefuelTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/PumpControllerRefuelTests.cs
@@ -169,6 +169,23 @@ public class PumpControllerRefuelTests
     }
 
     [Test]
+    public async Task Refuel_ReturnsBadRequest_WhenModelStateInvalid()
+    {
+        var (_, customer) = CreateCustomer(9, 50m);
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        _controller.ControllerContext.HttpContext.Items["PumpControllerUid"] = _pump.Uid;
+        _controller.ControllerContext.HttpContext.Items["UserUid"] = customer.Uid;
+        _controller.ModelState.AddModelError("TankNumber", "required");
+
+        var req = new RefuelRequest { TankNumber = 1, RefuelVolume = 10m };
+        var result = await _controller.Refuel(req);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
     public async Task Refuel_ReturnsForbidden_WhenUserUidMissing()
     {
         _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
@@ -283,7 +300,7 @@ public class PumpControllerRefuelTests
 
         Assert.That(isValid, Is.False);
         Assert.That(results.Any(r => r.MemberNames.Contains(nameof(RefuelRequest.TankNumber)) &&
-                                    r.ErrorMessage!.Contains("номер резервуара должен быть положительным числом")), Is.True);
+                                    r.ErrorMessage!.Contains("РЅРѕРјРµСЂ СЂРµР·РµСЂРІСѓР°СЂР° РґРѕР»Р¶РµРЅ Р±С‹С‚СЊ РїРѕР»РѕР¶РёС‚РµР»СЊРЅС‹Рј С‡РёСЃР»РѕРј")), Is.True);
     }
 
     [Test]
@@ -310,7 +327,7 @@ public class PumpControllerRefuelTests
 
         Assert.That(isValid, Is.False);
         Assert.That(results.Any(r => r.MemberNames.Contains(nameof(RefuelRequest.RefuelVolume)) &&
-                                    r.ErrorMessage!.Contains("объем заправленного топлива должен быть положительным числом")), Is.True);
+                                    r.ErrorMessage!.Contains("РѕР±СЉРµРј Р·Р°РїСЂР°РІР»РµРЅРЅРѕРіРѕ С‚РѕРїР»РёРІР° РґРѕР»Р¶РµРЅ Р±С‹С‚СЊ РїРѕР»РѕР¶РёС‚РµР»СЊРЅС‹Рј С‡РёСЃР»РѕРј")), Is.True);
     }
 
     [Test]

--- a/Fuelflux.Core.Tests/Controllers/PumpControllerUserListTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/PumpControllerUserListTests.cs
@@ -122,6 +122,30 @@ public class PumpControllerUserListTests
     }
 
     [Test]
+    public async Task GetPumpUsers_ReturnsBadRequest_WhenModelStateInvalid()
+    {
+        _controller.ModelState.AddModelError("First", "required");
+        var req = new PumpUserRequest { First = 0, Number = 1 };
+        var result = await _controller.GetPumpUsers(req);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
+    public async Task GetPumpUsers_ReturnsForbidden_WhenUserUidMissing()
+    {
+        _controller.ControllerContext.HttpContext.Items.Remove("UserUid");
+        var req = new PumpUserRequest { First = 0, Number = 1 };
+        var result = await _controller.GetPumpUsers(req);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
     public void PumpUserRequest_Validation_RequiresNonNegativeFirst()
     {
         var request = new PumpUserRequest { First = -1, Number = 1 };


### PR DESCRIPTION
## Summary
- add Admin role check in authorize tests
- cover invalid ModelState for FuelIntake
- cover invalid ModelState for Refuel
- cover invalid ModelState and missing user for user list
- convert tests to UTF‑8

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834f4959dc8321a7890a95d4f9d7bb