### PR TITLE
Add FuelStation admin controller

### DIFF
--- a/Fuelflux.Core.Tests/Controllers/FuelStationControllerTests.cs
+++ b/Fuelflux.Core.Tests/Controllers/FuelStationControllerTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Fuelflux.Core.Controllers;
+using Fuelflux.Core.Data;
+using Fuelflux.Core.Models;
+using Fuelflux.Core.RestModels;
+using Fuelflux.Core.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Fuelflux.Core.Tests.Controllers;
+
+[TestFixture]
+public class FuelStationControllerTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _db;
+    private Mock<IHttpContextAccessor> _http;
+    private Mock<IUserInformationService> _uis;
+    private Mock<ILogger<FuelStationController>> _logger;
+    private FuelStationController _controller;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"fuelstation_controller_test_db_{System.Guid.NewGuid()}")
+            .Options;
+        _db = new AppDbContext(options);
+        _http = new Mock<IHttpContextAccessor>();
+        _uis = new Mock<IUserInformationService>();
+        _logger = new Mock<ILogger<FuelStationController>>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _db.Database.EnsureDeleted();
+        _db.Dispose();
+    }
+
+    private void SetCurrentUser(int id)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Items["UserId"] = id;
+        _http.Setup(x => x.HttpContext).Returns(ctx);
+        _controller = new FuelStationController(_http.Object, _db, _uis.Object, _logger.Object);
+    }
+
+    [Test]
+    public async Task PostStation_CreatesStation_WhenAdmin()
+    {
+        SetCurrentUser(1);
+        _uis.Setup(u => u.CheckAdmin(1)).ReturnsAsync(true);
+        var item = new FuelStationCreateItem { Name = "FS" };
+        var result = await _controller.PostStation(item);
+        Assert.That(result.Result, Is.TypeOf<CreatedAtActionResult>());
+        Assert.That(_db.FuelStations.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task PostStation_ReturnsForbidden_WhenNotAdmin()
+    {
+        SetCurrentUser(2);
+        _uis.Setup(u => u.CheckAdmin(2)).ReturnsAsync(false);
+        var item = new FuelStationCreateItem { Name = "FS" };
+        var result = await _controller.PostStation(item);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task PutTank_ReturnsNotFound_WhenTankMissing()
+    {
+        SetCurrentUser(1);
+        _uis.Setup(u => u.CheckAdmin(1)).ReturnsAsync(true);
+        var update = new FuelTankUpdateItem { Number = 1 };
+        var result = await _controller.PutTank(1, update);
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task GetPumps_ReturnsList_WhenAdmin()
+    {
+        var fs = new FuelStation { Id = 1, Name = "fs" };
+        var pump = new PumpCntrl { Id = 1, Uid = "u", FuelStationId = 1, FuelStation = fs };
+        _db.FuelStations.Add(fs);
+        _db.PumpControllers.Add(pump);
+        await _db.SaveChangesAsync();
+        SetCurrentUser(1);
+        _uis.Setup(u => u.CheckAdmin(1)).ReturnsAsync(true);
+        var result = await _controller.GetPumps();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetPumps_ReturnsForbidden_WhenNotAdmin()
+    {
+        SetCurrentUser(2);
+        _uis.Setup(u => u.CheckAdmin(2)).ReturnsAsync(false);
+        var result = await _controller.GetPumps();
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+}

--- a/Fuelflux.Core/Controllers/FuelStationController.cs
+++ b/Fuelflux.Core/Controllers/FuelStationController.cs
@@ -1,0 +1,236 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using Fuelflux.Core.Authorization;
+using Fuelflux.Core.RestModels;
+using Fuelflux.Core.Data;
+using Fuelflux.Core.Models;
+using Fuelflux.Core.Services;
+
+namespace Fuelflux.Core.Controllers;
+
+[ApiController]
+[Authorize(AuthorizationType.User)]
+[Route("api/[controller]")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+public class FuelStationController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    IUserInformationService userInformationService,
+    ILogger<FuelStationController> logger) : FuelfluxControllerBase(httpContextAccessor, db, logger)
+{
+    private readonly IUserInformationService _uis = userInformationService;
+
+    #region FuelStation
+    [HttpGet("stations")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<FuelStationItem>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<IEnumerable<FuelStationItem>>> GetStations()
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var items = await _db.FuelStations.AsNoTracking()
+            .Select(fs => new FuelStationItem(fs)).ToListAsync();
+        return items;
+    }
+
+    [HttpGet("stations/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FuelStationItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<FuelStationItem>> GetStation(int id)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var fs = await _db.FuelStations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id);
+        if (fs == null) return _404FuelStation(id);
+        return new FuelStationItem(fs);
+    }
+
+    [HttpPost("stations")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<Reference>> PostStation(FuelStationCreateItem item)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var fs = new FuelStation { Name = item.Name };
+        _db.FuelStations.Add(fs);
+        await _db.SaveChangesAsync();
+        var reference = new Reference { Id = fs.Id };
+        return CreatedAtAction(nameof(PostStation), new { id = fs.Id }, reference);
+    }
+
+    [HttpPut("stations/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> PutStation(int id, FuelStationUpdateItem item)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var fs = await _db.FuelStations.FindAsync(id);
+        if (fs == null) return _404FuelStation(id);
+        if (item.Name != null) fs.Name = item.Name;
+        _db.Entry(fs).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("stations/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteStation(int id)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var fs = await _db.FuelStations.FindAsync(id);
+        if (fs == null) return _404FuelStation(id);
+        _db.FuelStations.Remove(fs);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+    #endregion
+
+    #region FuelTank
+    [HttpGet("tanks")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<FuelTankViewItem>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<IEnumerable<FuelTankViewItem>>> GetTanks()
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var items = await _db.FuelTanks.AsNoTracking()
+            .Select(t => new FuelTankViewItem(t)).ToListAsync();
+        return items;
+    }
+
+    [HttpGet("tanks/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FuelTankViewItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<FuelTankViewItem>> GetTank(int id)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var tank = await _db.FuelTanks.AsNoTracking().FirstOrDefaultAsync(t => t.Id == id);
+        if (tank == null) return _404FuelTank(id);
+        return new FuelTankViewItem(tank);
+    }
+
+    [HttpPost("tanks")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<Reference>> PostTank(FuelTankCreateItem item)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var tank = new FuelTank
+        {
+            Number = item.Number,
+            Allowance = item.Allowance ?? 0m,
+            FuelStationId = item.FuelStationId
+        };
+        _db.FuelTanks.Add(tank);
+        await _db.SaveChangesAsync();
+        var reference = new Reference { Id = tank.Id };
+        return CreatedAtAction(nameof(PostTank), new { id = tank.Id }, reference);
+    }
+
+    [HttpPut("tanks/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> PutTank(int id, FuelTankUpdateItem item)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var tank = await _db.FuelTanks.FindAsync(id);
+        if (tank == null) return _404FuelTank(id);
+        if (item.Number != null) tank.Number = item.Number.Value;
+        if (item.Allowance != null) tank.Allowance = item.Allowance.Value;
+        if (item.FuelStationId != null) tank.FuelStationId = item.FuelStationId.Value;
+        _db.Entry(tank).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("tanks/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteTank(int id)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var tank = await _db.FuelTanks.FindAsync(id);
+        if (tank == null) return _404FuelTank(id);
+        _db.FuelTanks.Remove(tank);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+    #endregion
+
+    #region PumpController
+    [HttpGet("pumps")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PumpControllerItem>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<IEnumerable<PumpControllerItem>>> GetPumps()
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var items = await _db.PumpControllers.AsNoTracking()
+            .Select(p => new PumpControllerItem(p)).ToListAsync();
+        return items;
+    }
+
+    [HttpGet("pumps/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PumpControllerItem))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<PumpControllerItem>> GetPump(int id)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var pump = await _db.PumpControllers.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id);
+        if (pump == null) return _404PumpController(id);
+        return new PumpControllerItem(pump);
+    }
+
+    [HttpPost("pumps")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(Reference))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<Reference>> PostPump(PumpControllerCreateItem item)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var pump = new PumpCntrl
+        {
+            Uid = item.Uid,
+            FuelStationId = item.FuelStationId
+        };
+        _db.PumpControllers.Add(pump);
+        await _db.SaveChangesAsync();
+        var reference = new Reference { Id = pump.Id };
+        return CreatedAtAction(nameof(PostPump), new { id = pump.Id }, reference);
+    }
+
+    [HttpPut("pumps/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> PutPump(int id, PumpControllerUpdateItem item)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var pump = await _db.PumpControllers.FindAsync(id);
+        if (pump == null) return _404PumpController(id);
+        if (item.Uid != null) pump.Uid = item.Uid;
+        if (item.FuelStationId != null) pump.FuelStationId = item.FuelStationId.Value;
+        _db.Entry(pump).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("pumps/{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeletePump(int id)
+    {
+        if (!await _uis.CheckAdmin(_curUserId)) return _403();
+        var pump = await _db.PumpControllers.FindAsync(id);
+        if (pump == null) return _404PumpController(id);
+        _db.PumpControllers.Remove(pump);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+    #endregion
+}

--- a/Fuelflux.Core/Controllers/FuelfluxControllerBase.cs
+++ b/Fuelflux.Core/Controllers/FuelfluxControllerBase.cs
@@ -80,6 +80,16 @@ public class FuelfluxControllerPreBase(AppDbContext db, ILogger logger) : Contro
         return StatusCode(StatusCodes.Status404NotFound,
                           new ErrMessage { Msg = $"Не удалось найти топливный бак [number={number}]" });
     }
+    protected ObjectResult _404FuelStation(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти АЗС [id={id}]" });
+    }
+    protected ObjectResult _404PumpController(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти контроллер ТРК [id={id}]" });
+    }
     protected ObjectResult _409Email(string email)
     {
         return StatusCode(StatusCodes.Status409Conflict,

--- a/Fuelflux.Core/RestModels/FuelStationCreateItem.cs
+++ b/Fuelflux.Core/RestModels/FuelStationCreateItem.cs
@@ -1,0 +1,6 @@
+namespace Fuelflux.Core.RestModels;
+
+public class FuelStationCreateItem
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/Fuelflux.Core/RestModels/FuelStationItem.cs
+++ b/Fuelflux.Core/RestModels/FuelStationItem.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using Fuelflux.Core.Models;
+using Fuelflux.Core.Settings;
+
+namespace Fuelflux.Core.RestModels;
+
+public class FuelStationItem(FuelStation fs)
+{
+    public int Id { get; set; } = fs.Id;
+    public string Name { get; set; } = fs.Name;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}

--- a/Fuelflux.Core/RestModels/FuelStationUpdateItem.cs
+++ b/Fuelflux.Core/RestModels/FuelStationUpdateItem.cs
@@ -1,0 +1,6 @@
+namespace Fuelflux.Core.RestModels;
+
+public class FuelStationUpdateItem
+{
+    public string? Name { get; set; }
+}

--- a/Fuelflux.Core/RestModels/FuelTankCreateItem.cs
+++ b/Fuelflux.Core/RestModels/FuelTankCreateItem.cs
@@ -1,0 +1,8 @@
+namespace Fuelflux.Core.RestModels;
+
+public class FuelTankCreateItem
+{
+    public decimal Number { get; set; }
+    public decimal? Allowance { get; set; }
+    public int FuelStationId { get; set; }
+}

--- a/Fuelflux.Core/RestModels/FuelTankUpdateItem.cs
+++ b/Fuelflux.Core/RestModels/FuelTankUpdateItem.cs
@@ -1,0 +1,8 @@
+namespace Fuelflux.Core.RestModels;
+
+public class FuelTankUpdateItem
+{
+    public decimal? Number { get; set; }
+    public decimal? Allowance { get; set; }
+    public int? FuelStationId { get; set; }
+}

--- a/Fuelflux.Core/RestModels/FuelTankViewItem.cs
+++ b/Fuelflux.Core/RestModels/FuelTankViewItem.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using Fuelflux.Core.Models;
+using Fuelflux.Core.Settings;
+
+namespace Fuelflux.Core.RestModels;
+
+public class FuelTankViewItem(FuelTank tank)
+{
+    public int Id { get; set; } = tank.Id;
+    public decimal Number { get; set; } = tank.Number;
+    public decimal Allowance { get; set; } = tank.Allowance;
+    public int FuelStationId { get; set; } = tank.FuelStationId;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}

--- a/Fuelflux.Core/RestModels/PumpControllerCreateItem.cs
+++ b/Fuelflux.Core/RestModels/PumpControllerCreateItem.cs
@@ -1,0 +1,7 @@
+namespace Fuelflux.Core.RestModels;
+
+public class PumpControllerCreateItem
+{
+    public string Uid { get; set; } = string.Empty;
+    public int FuelStationId { get; set; }
+}

--- a/Fuelflux.Core/RestModels/PumpControllerItem.cs
+++ b/Fuelflux.Core/RestModels/PumpControllerItem.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using Fuelflux.Core.Models;
+using Fuelflux.Core.Settings;
+
+namespace Fuelflux.Core.RestModels;
+
+public class PumpControllerItem(PumpCntrl pump)
+{
+    public int Id { get; set; } = pump.Id;
+    public string Uid { get; set; } = pump.Uid;
+    public int FuelStationId { get; set; } = pump.FuelStationId;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}

--- a/Fuelflux.Core/RestModels/PumpControllerUpdateItem.cs
+++ b/Fuelflux.Core/RestModels/PumpControllerUpdateItem.cs
@@ -1,0 +1,7 @@
+namespace Fuelflux.Core.RestModels;
+
+public class PumpControllerUpdateItem
+{
+    public string? Uid { get; set; }
+    public int? FuelStationId { get; set; }
+}


### PR DESCRIPTION
## Summary
- add controller for managing stations, tanks and pumps
- introduce DTOs for the new endpoints
- extend base controller with additional 404 helpers
- add unit tests for the new controller

## Testing
- `dotnet build Fuelflux.sln -c Release`
- `dotnet test Fuelflux.Core.Tests/Fuelflux.Core.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68835dadc25c8321a2c810e21280b7ce